### PR TITLE
Add "\" as the Path Separator for Windows

### DIFF
--- a/lua/generate/filesystem.lua
+++ b/lua/generate/filesystem.lua
@@ -17,11 +17,15 @@ local exension_index = {
 local source_dir_names = { 'source', 'src' }
 local include_dir_names = { 'include', 'inc' }
 
+-- use \ as separator for paths if on Windows
+local is_windows = vim.fn.has("win32") or vim.fn.has("win64")
+local separator = is_windows and "\\" or "/"
+
 -- Logically is something like 'cd ..'
 local function remove_basename(filepath)
   local first = nil
   for i = #filepath, 1, -1 do
-    if string.sub(filepath, i, i) == '/' then
+    if string.sub(filepath, i, i) == separator then
       first = i
       break
     end


### PR DESCRIPTION
Hey, right now the commands mess up on Windows because of the backslash vs. forward slash thing in paths. 
So I added a quick check for the operating system. If it's Windows, we switch to using backslashes (\), and it should make the commands work smoothly on both Windows and other systems.
