### PR TITLE
Decide cpp file by using lsp in a async way

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and the C++ parser, which can be installed via `:TSInstall cpp`
 require('lazy').setup({
   {
     'eriks47/generate.nvim',
-    dependencies = { 'nvim-treesitter/nvim-treesitter' }
+    dependencies = { 'nvim-treesitter/nvim-treesitter' , "neovim/nvim-lspconfig"}
   }
 })
 ```

--- a/lua/generate/init.lua
+++ b/lua/generate/init.lua
@@ -8,6 +8,7 @@ local M = {}
 local api = vim.api
 local ts = vim.treesitter
 local uv = vim.loop
+local fs = require('generate.filesystem')
 
 api.nvim_create_user_command('Generate', function(params)
   local header = require('generate.header')
@@ -20,8 +21,32 @@ api.nvim_create_user_command('Generate', function(params)
   local arg = params.fargs[1]
   if arg == 'implementations' then
     local namespaces = header.get_declarations(root)
-    source.insert_header(path)
-    source.implement_methods(namespaces)
+    -- asynchronously get the implementations file (*.cpp) path
+    local util = require 'lspconfig.util'
+    local bufnr = vim.api.nvim_get_current_buf()
+    bufnr = util.validate_bufnr(bufnr)
+    local clangd_client = util.get_active_client_by_name(bufnr, 'clangd')
+    local hparams = { uri = vim.uri_from_fname(path) }
+    if clangd_client then
+      clangd_client.request('textDocument/switchSourceHeader', hparams, function(err, result)
+        local filepath = nil
+        -- async here
+        if err or (not result) then
+          print('query clangd cpp file faild, err is ', tostring(err))
+          filepath = fs.header_to_source(path)
+        end
+        -- get cpp file
+        if result then
+          filepath = vim.uri_to_fname(result)
+        end
+        source.insert_header(path, filepath)
+        source.implement_methods(namespaces)
+      end, bufnr)
+    else
+      -- no lsp avaliable 
+      source.insert_header(path, fs.header_to_source(path))
+      source.implement_methods(namespaces)
+    end
   end
 end, {
   bang = false,

--- a/lua/generate/source.lua
+++ b/lua/generate/source.lua
@@ -120,8 +120,7 @@ function M.implement_methods(namespaces)
   api.nvim_command(":edit")
 end
 
-function M.insert_header(header_path)
-  local source_path = fs.header_to_source(header_path)
+function M.insert_header(header_path, source_path)
   local name = fn.fnamemodify(header_path, ':t')
   local header_text = '#include "' .. name .. '"'
 


### PR DESCRIPTION
The PR implements a new way to get corresponding cpp file path by query lsp. 
this plugin will automatically creating file following previous rules if there is no cpp file corresponding to the header file in lsp parsing. 